### PR TITLE
Add toggleable weekend exclusion and daily remaining requests calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@
 | `cursorStats.showProgressBars` | Enable progress visualization | `false` |
 | `cursorStats.progressBarLength` | Progress bar length (for progress visualization) | `10` |
 | `cursorStats.customDatabasePath` | Custom path to Cursor database | `""` |
+| `cursorStats.excludeWeekends` | Exclude weekends from period progress and daily calculations | `false` |
+| `cursorStats.showDailyRemaining` | Show estimated fast requests remaining per day | `false` |
 
 </details>
 

--- a/package.json
+++ b/package.json
@@ -274,6 +274,18 @@
             "default": "",
             "description": "Custom path to the Cursor database file. Leave empty to use default location.",
             "scope": "window"
+          },
+          "cursorStats.excludeWeekends": {
+            "type": "boolean",
+            "default": false,
+            "description": "Exclude weekends from period progress calculations and daily remaining requests.",
+            "scope": "window"
+          },
+          "cursorStats.showDailyRemaining": {
+            "type": "boolean",
+            "default": false,
+            "description": "Show estimated fast requests remaining per day in the tooltip.",
+            "scope": "window"
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,7 @@ import {
 import { updateStats } from './utils/updateStats';
 import { SUPPORTED_CURRENCIES } from './utils/currency';
 import { convertAndFormatCurrency } from './utils/currency';
-import { createReportCommand} from './utils/report';
+import { createReportCommand } from './utils/report';
 
 let statusBarItem: vscode.StatusBarItem;
 let extensionContext: vscode.ExtensionContext;
@@ -131,10 +131,13 @@ export async function activate(context: vscode.ExtensionContext) {
             }
         });
 
-        // Add configuration change listener
-        const configListener = vscode.workspace.onDidChangeConfiguration(async (e) => {
-            if (e.affectsConfiguration('cursorStats.enableStatusBarColors')) {
-                log('[Settings] Status bar colors setting changed, updating display...');
+    // Add configuration change listener
+    const configListener = vscode.workspace.onDidChangeConfiguration(
+      async (e) => {
+        if (e.affectsConfiguration('cursorStats.enableStatusBarColors')) {
+          log(
+            '[Settings] Status bar colors setting changed, updating display...'
+          );
                 await updateStats(statusBarItem);
             }
             if (e.affectsConfiguration('cursorStats.refreshInterval')) {
@@ -142,15 +145,29 @@ export async function activate(context: vscode.ExtensionContext) {
                 startRefreshInterval();
             }
             if (e.affectsConfiguration('cursorStats.showTotalRequests')) {
-                log('[Settings] Show total requests setting changed, updating display...');
+          log(
+            '[Settings] Show total requests setting changed, updating display...'
+          );
                 await updateStats(statusBarItem);
             }
             if (e.affectsConfiguration('cursorStats.currency')) {
                 log('[Settings] Currency setting changed, updating display...');
                 await updateStats(statusBarItem);
             }
-        });
-        
+        if (e.affectsConfiguration('cursorStats.excludeWeekends')) {
+          log(
+            '[Settings] Exclude weekends setting changed, updating display...'
+          );
+          await updateStats(statusBarItem);
+        }
+        if (e.affectsConfiguration('cursorStats.showDailyRemaining')) {
+          log(
+            '[Settings] Show daily remaining setting changed, updating display...'
+          );
+          await updateStats(statusBarItem);
+        }
+      }
+    );
 
         const setLimitCommand = vscode.commands.registerCommand('cursor-stats.setLimit', async () => {
             const token = await getCursorTokenFromDB();


### PR DESCRIPTION
## 🚀 Feature: Weekend Exclusion & Daily Remaining Requests

This PR implements the feature I requested in issue #39 to add weekend exclusion options and daily remaining request calculations for better request budgeting.

### ✨ What's New

**Weekend Exclusion Mode**
- New setting `cursorStats.excludeWeekends` to exclude weekends from period progress calculations
- Period progress bar accurately reflects weekday-only usage when enabled
- Visual indicator shows "📅 Weekdays only mode enabled" when active

**Daily Remaining Requests**
- New setting `cursorStats.showDailyRemaining` to display estimated requests remaining per day
- Smart calculation: `remaining requests ÷ days left` (respects weekend exclusion)
- Two-line format to keep tooltip compact: main stat + calculation breakdown

### 🎯 Benefits

- **More accurate budgeting** for weekday-only Cursor users
- **Better request planning** with daily remaining estimates
- **Independent toggles** - daily remaining works with or without progress bars
- **Seamless integration** - respects existing progress bar settings

### 🔧 Settings Added

| Setting | Description | Default |
|---------|-------------|---------|
| `cursorStats.excludeWeekends` | Exclude weekends from period progress and daily calculations | `false` |
| `cursorStats.showDailyRemaining` | Show estimated fast requests remaining per day | `false` |
